### PR TITLE
refactor: move CVI to latent space, CVHM as bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@ JAX_ENABLE_X64=1 pytest -x --maxfail=1
 JAX_ENABLE_X64=1 pytest --lf          # rerun last failures
 JAX_ENABLE_X64=1 pytest --ff          # run last failures first
 
+# Benchmark (slow, ~30 s; skipped by default)
+JAX_ENABLE_X64=1 pytest tests/test_benchmark.py --run-slow
+
 # Build (sdist/wheel)
 python -m build
 # (Alternative, if hatch is installed)
@@ -109,6 +112,19 @@ export XLA_FLAGS=--xla_force_host_platform_device_count=1  # CPU-only / debuggin
 2. Ensure it registers via `__init_subclass__`.
 3. Add tests under `tests/` mirroring the module layout.
 4. Update docstrings and `docs/api.md`.
+
+## Benchmark Regression Guard
+
+Any change that affects inference quality **must** pass the benchmark:
+
+```bash
+JAX_ENABLE_X64=1 pytest tests/test_benchmark.py --run-slow
+```
+
+The benchmark runs three Poisson-VdP scenarios (frozen readout, estimated
+readout, variable-length trials) and asserts R² ≥ 0.96.  Baseline R² is
+~0.972 on all three.  If a change drops below the floor, either fix the
+regression or update the floor with justification.
 
 ## Docs Update Rule
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,11 +24,25 @@ Source: `src/cvhmax/cvhm.py`
 
 ## CVI and Readouts
 
-- `CVI`: registry-backed base class
-- `Gaussian`, `Poisson`: implementations of likelihood-specific updates
-- `Params`: container of `C`, `d`, `R`, `M`
+- `CVI`: registry-backed base class with stateless abstract methods
+  - `initialize_params(y, valid_y, n_factors, *, random_state)` — create params
+  - `initialize_info(params, y, valid_y)` — pseudo-obs info in latent space
+  - `update_pseudo(params, y, valid_y, m, V, j, J, lr)` — CVI update in latent space
+  - `update_readout(params, y, valid_y, m, V)` — M-step for observation params
+- `Gaussian`, `Poisson`: built-in readouts
+- `Params`: convenience container of `C`, `d`, `R` (no `M` — that lives in CVHM)
+
+CVI methods work entirely in latent space `(K)`. The params structure is
+opaque to CVHM — each subclass may use any pytree-compatible container.
 
 Source: `src/cvhmax/cvi.py`
+
+## Conversion Helpers
+
+- `lift(j_latent, J_latent, M)` — latent→state information
+- `project(z, Z, M)` — state→latent posterior (delegates to `sde2gp`)
+
+Source: `src/cvhmax/cvhm.py`
 
 ## Kernels
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,127 @@
+# Architecture
+
+This page describes the high-level design of cvhmax and the separation of
+concerns between its core components.
+
+## Three-Way Separation
+
+The codebase enforces a strict boundary between three components.  Each
+component works in its own space and communicates through CVHM, which acts
+as a bridge.
+
+```
+CVI (observation model)     CVHM (bridge)     Filtering (dynamics)
+    latent space (K)     ←——— M ———→          state space (L)
+```
+
+| Component | Space | Knows about | Responsibility |
+|-----------|-------|-------------|----------------|
+| CVI | latent `(K)` | observations only | information updates, readout params |
+| Filtering | state `(L)` | dynamics only | information-form smoothing |
+| CVHM | both via `M` | bridge | `lift`, `project`, loop orchestration |
+
+### Data Flow
+
+```
+CVI                          CVHM                         Filtering
+(latent space)               (bridge)                     (state space)
+
+observations ──→ initialize_info ──→ j_latent, J_latent
+                                           │
+                                     lift (j @ M, M.T @ J @ M)
+                                           │
+                                           ▼                      ← warm-up
+                              j, J ──→ forward_filter ──→ zp, Zp  (predicted)
+                                           │
+                                     project (sde2gp)
+                                           │
+                                           ▼
+                              m_w, V_w ─→ update_pseudo ──→ j_latent, J_latent
+                                           │
+                                     lift (j @ M, M.T @ J @ M)
+                                           │
+                                           ▼                      ← CVI loop
+                              j, J ──→ bifilter ──→ z, Z
+                                           │
+                                     project (sde2gp)
+                                           │
+                                           ▼
+                              m, V ──→ update_pseudo ──→ j_latent, J_latent
+                                           │
+                                         (repeat)
+                                           │
+                                           ▼
+                              m, V ──→ update_readout ──→ params
+```
+
+## Spaces and Dimensions
+
+| Space | Dimension | Owner | Purpose |
+|-------|-----------|-------|---------|
+| state | `L = 2 * sum(nple)` | Filtering | SDE dynamics |
+| latent | `K = n_components` | CVI | observation model |
+
+The selection mask `M` (shape `(K, L)`) is a structural constant
+determined by the kernel configuration.  It is owned by CVHM and never
+passed to CVI.
+
+## Conversion Formulas (owned by CVHM)
+
+**lift** (latent → state information):
+```
+j_state = j_latent @ M              # (..., K) → (..., L)
+J_state = M.T @ J_latent @ M        # (..., K, K) → (..., L, L)
+```
+
+**project** (state information → latent moments):
+```
+m, V = sde2gp(z, Z, M)
+# m = solve(Z, z) @ M.T             # (..., L) → (..., K)
+# V = M @ inv(Z) @ M.T              # (..., L, L) → (..., K, K)
+```
+
+## Forward-Filter Warm-Up
+
+After `initialize_info` returns per-bin pseudo-observations (computed
+independently at each time bin), CVHM runs a single forward information
+filter pass before the CVI loop.  This propagates causal information
+across bins so that each bin's pseudo-observations are seeded from a
+sequentially coherent prediction rather than a zero-mean prior.
+
+The warm-up is a state-space operation (it uses `Af`, `Pf`) and therefore
+belongs in CVHM, not CVI.  It uses the **predicted** (one-step-ahead)
+states — not the posteriors — to avoid double-counting the current bin's
+observation.  The resulting latent moments are passed to `update_pseudo`
+with `lr=1.0` to fully replace the initial pseudo-observations.
+
+For conjugate readouts (Gaussian) the warm-up is idempotent because
+`update_pseudo` returns the same pseudo-observations regardless of the
+posterior.
+
+## Observation Model Interface
+
+CVI subclasses implement four stateless class methods, all operating in
+latent space:
+
+| Method | Input | Output |
+|--------|-------|--------|
+| `initialize_params` | observations | opaque params |
+| `initialize_info` | params, observations | `(j, J)` in latent space |
+| `update_pseudo` | params, observations, posterior `(m, V)`, current `(j, J)` | updated `(j, J)` in latent space |
+| `update_readout` | params, observations, posterior `(m, V)` | updated params |
+
+### Duck-typed params
+
+The params structure is opaque to CVHM.  Each CVI subclass may use any
+pytree-compatible container — a tuple, a dataclass, an equinox `Module`,
+or anything else.  The built-in `Gaussian` and `Poisson` readouts use the
+`Params` dataclass (with fields `C`, `d`, `R`), but this is not required.
+
+## Benefits
+
+1. **Clean separation**: CVI knows nothing about state space; filtering
+   knows nothing about observations; CVHM bridges the two.
+2. **Easy to extend**: new observation models only need to implement four
+   stateless methods in latent space.
+3. **Smaller arrays in CVI**: latent dimension `K ≤ L`, less computation.
+4. **Testable**: each CVI method is a pure function of its inputs.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -57,15 +57,16 @@ total state dimension is therefore `L = 2 * sum(kernel.nple)` over all
 
 ### Key matrix shapes
 
-| Matrix | Shape | Role |
-|--------|-------|------|
-| `y` | `(trials, T, N)` | observations |
-| `C` | `(N, K)` | loading matrix |
-| `M` | `(K, L)` | latent mask / selection matrix |
-| `H = C @ M` | `(N, L)` | effective observation matrix |
-| `Af`, `Qf`, etc. | `(L, L)` | SDE transition / process noise |
-| `z`, `Z` | `(trials, T, L)` / `(trials, T, L, L)` | information-form SDE state |
-| `m`, `V` | `(trials, T, K)` / `(trials, T, K, K)` | GP posterior mean / covariance |
+| Matrix | Shape | Space | Role |
+|--------|-------|-------|------|
+| `y` | `(trials, T, N)` | observation | observations |
+| `C` | `(N, K)` | latent | loading matrix |
+| `M` | `(K, L)` | bridge | latent mask / selection matrix (owned by CVHM) |
+| `Af`, `Qf`, etc. | `(L, L)` | state | SDE transition / process noise |
+| `j`, `J` (CVI) | `(trials, T, K)` / `(trials, T, K, K)` | latent | pseudo-observation info |
+| `j`, `J` (filter) | `(trials, T, L)` / `(trials, T, L, L)` | state | pseudo-observation info (after lift) |
+| `z`, `Z` | `(trials, T, L)` / `(trials, T, L, L)` | state | information-form SDE posterior |
+| `m`, `V` | `(trials, T, K)` / `(trials, T, K, K)` | latent | GP posterior mean / covariance |
 
 ## Latent Outputs
 

--- a/examples/demo_vdp.py
+++ b/examples/demo_vdp.py
@@ -309,9 +309,6 @@ def main():
         C=jnp.asarray(C_true),
         d=jnp.asarray(d_true),
         R=None,
-        M=CVHM(
-            n_components=n_latents, dt=dt, kernels=kernels, observation="FrozenPoisson"
-        ).latent_mask(),
     )
     run_case(
         y,

--- a/src/cvhmax/__init__.py
+++ b/src/cvhmax/__init__.py
@@ -1,4 +1,4 @@
-from .cvhm import CVHM
+from .cvhm import CVHM, lift, project
 from .cvi import CVI, Gaussian, Poisson, Params
 from .hm import HidaMatern
 from .utils import pad_trials, unpad_trials
@@ -10,6 +10,8 @@ __all__ = [
     "Poisson",
     "Params",
     "HidaMatern",
+    "lift",
+    "project",
     "pad_trials",
     "unpad_trials",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,11 +39,33 @@ def _torch_and_ref_available():
 # ---------------------------------------------------------------------------
 # Markers
 # ---------------------------------------------------------------------------
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-slow",
+        action="store_true",
+        default=False,
+        help="Run tests marked as slow (e.g. benchmarks).",
+    )
+
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers",
         "parity: cross-implementation parity tests (require torch + ref code)",
     )
+    config.addinivalue_line(
+        "markers",
+        "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--run-slow"):
+        return
+    skip_slow = pytest.mark.skip(reason="need --run-slow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
 
 
 # convenience skip decorator used in test_parity.py

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,178 @@
+"""Benchmark tests: regression guard for inference quality.
+
+These tests reproduce the three demo scenarios from ``examples/demo_vdp.py``
+and assert that R² stays above a hard floor.  They are marked ``slow``
+(~40 s each) and skipped by default — run with::
+
+    JAX_ENABLE_X64=1 pytest tests/test_benchmark.py --run-slow
+
+Baseline R² (recorded on the ``refactor/latent-space-cvi`` branch):
+
+    Frozen readout:       0.972
+    Estimated readout:    0.972
+    Variable-length:      0.972
+
+The hard floor is set to 0.96 to allow minor platform/JAX-version jitter.
+"""
+
+import numpy as np
+import pytest
+
+from jax import numpy as jnp
+
+from cvhmax.cvhm import CVHM
+from cvhmax.cvi import Params
+from cvhmax.hm import HidaMatern
+from cvhmax.utils import pad_trials, unpad_trials
+
+
+# ---------------------------------------------------------------------------
+# Shared constants & helpers
+# ---------------------------------------------------------------------------
+
+R2_FLOOR = 0.96
+
+N_TRIALS = 10
+T = 500
+DT = 0.02
+MU = 1.0
+N_OBS = 50
+N_LATENTS = 2
+BASELINE_RATE = 5.0
+
+
+def _vdp_rhs(state, mu):
+    x, v = state
+    return np.array([v, mu * (1 - x**2) * v - x])
+
+
+def _simulate_vdp(rng, n_trials, T, dt, mu, noise_std=0.05):
+    sqrt_dt = np.sqrt(dt)
+    out = np.empty((n_trials, T, 2))
+    for trial in range(n_trials):
+        s = np.array([2.0 + rng.normal(0, 0.1), rng.normal(0, 0.1)])
+        for t in range(T):
+            out[trial, t] = s
+            s = s + _vdp_rhs(s, mu) * dt + noise_std * sqrt_dt * rng.standard_normal(2)
+    return out
+
+
+def _standardize(x):
+    flat = x.reshape(-1, x.shape[-1])
+    mu, sigma = flat.mean(0), flat.std(0)
+    return (x - mu) / sigma
+
+
+def _r2(m, x_true):
+    """Pooled R² after affine alignment."""
+    K = m.shape[-1]
+    mf = m.reshape(-1, K)
+    xf = x_true.reshape(-1, K)
+    A = np.hstack([mf, np.ones((mf.shape[0], 1))])
+    W, _, _, _ = np.linalg.lstsq(A, xf, rcond=None)
+    aligned = A @ W
+    ss_res = np.sum((aligned - xf) ** 2)
+    ss_tot = np.sum((xf - xf.mean(0)) ** 2)
+    return 1.0 - ss_res / ss_tot
+
+
+def _make_data(rng):
+    """Simulate VdP + Poisson observations (deterministic given rng)."""
+    x_raw = _simulate_vdp(rng, N_TRIALS, T, DT, MU)
+    x_std = _standardize(x_raw)
+
+    C_true = rng.standard_normal((N_OBS, N_LATENTS))
+    C_true /= np.linalg.norm(C_true, axis=0, keepdims=True)
+    d_true = np.full(N_OBS, np.log(BASELINE_RATE))
+
+    log_rate = np.einsum("ntl,ol->nto", x_std, C_true) + d_true[None, None, :]
+    y_np = rng.poisson(np.exp(log_rate))
+    y = jnp.asarray(y_np, dtype=jnp.float64)
+
+    return y, y_np, x_std, C_true, d_true
+
+
+def _kernels():
+    return [HidaMatern(sigma=1.0, rho=1.0, omega=0.0, order=1) for _ in range(N_LATENTS)]
+
+
+# ---------------------------------------------------------------------------
+# Frozen-readout Poisson subclass (same as demo)
+# ---------------------------------------------------------------------------
+
+from cvhmax.cvi import Poisson  # noqa: E402
+
+
+class FrozenPoisson(Poisson):
+    @classmethod
+    def update_readout(cls, params, y, valid_y, m, V):
+        return params, jnp.nan
+
+
+# ---------------------------------------------------------------------------
+# Benchmark tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.slow
+def test_benchmark_frozen_readout():
+    rng = np.random.default_rng(2024)
+    y, _, x_std, C_true, d_true = _make_data(rng)
+    kernels = _kernels()
+
+    true_params = Params(C=jnp.asarray(C_true), d=jnp.asarray(d_true), R=None)
+
+    model = CVHM(
+        n_components=N_LATENTS, dt=DT, kernels=kernels,
+        observation="FrozenPoisson", max_iter=50, cvi_iter=5,
+    )
+    model.params = true_params
+    model.fit(y, random_state=42)
+
+    r2 = _r2(np.asarray(model.posterior[0]), x_std)
+    assert r2 >= R2_FLOOR, f"Frozen readout R²={r2:.4f} < {R2_FLOOR}"
+
+
+@pytest.mark.slow
+def test_benchmark_estimated_readout():
+    rng = np.random.default_rng(2024)
+    y, _, x_std, _, _ = _make_data(rng)
+    kernels = _kernels()
+
+    model = CVHM(
+        n_components=N_LATENTS, dt=DT, kernels=kernels,
+        observation="Poisson", max_iter=50, cvi_iter=5,
+    )
+    model.fit(y, random_state=42)
+
+    r2 = _r2(np.asarray(model.posterior[0]), x_std)
+    assert r2 >= R2_FLOOR, f"Estimated readout R²={r2:.4f} < {R2_FLOOR}"
+
+
+@pytest.mark.slow
+def test_benchmark_variable_length():
+    rng = np.random.default_rng(2024)
+    y, y_np, x_std, _, _ = _make_data(rng)
+    kernels = _kernels()
+
+    trial_lengths_np = rng.integers(250, 501, size=N_TRIALS)
+    y_list = [
+        jnp.asarray(y_np[i, :tl], dtype=jnp.float64)
+        for i, tl in enumerate(trial_lengths_np)
+    ]
+    x_list = [x_std[i, :tl] for i, tl in enumerate(trial_lengths_np)]
+
+    y_padded, valid_y, trial_lengths = pad_trials(y_list)
+
+    model = CVHM(
+        n_components=N_LATENTS, dt=DT, kernels=kernels,
+        observation="Poisson", max_iter=50, cvi_iter=5,
+    )
+    model.fit(y_padded, valid_y=valid_y, random_state=42)
+
+    m_list = unpad_trials(model.posterior[0], trial_lengths)
+    m_all = np.concatenate([np.asarray(mi) for mi in m_list])
+    x_all = np.concatenate(x_list)
+
+    r2 = _r2(m_all, x_all)
+    assert r2 >= R2_FLOOR, f"Variable-length R²={r2:.4f} < {R2_FLOOR}"

--- a/tests/test_cvi.py
+++ b/tests/test_cvi.py
@@ -5,7 +5,13 @@ import chex
 from jax import numpy as jnp
 from sklearn.linear_model import LinearRegression
 
-from cvhmax.cvi import Params, poisson_cvi_bin_stats, Poisson, Gaussian
+from cvhmax.cvi import (
+    Params,
+    poisson_cvi_bin_stats,
+    poisson_cvi_bin_stats_latent,
+    Poisson,
+    Gaussian,
+)
 from cvhmax.cvhm import CVHM
 from cvhmax.hm import HidaMatern
 from cvhmax.utils import norm_loading
@@ -51,44 +57,17 @@ def test_gaussian_initialize_info_values(rng):
 
 def test_gaussian_update_pseudo_noop():
     """Gaussian.update_pseudo returns its inputs unchanged."""
-    L = 3
+    K = 3
     T = 10
-    j = jnp.ones((1, T, L))
-    J = jnp.tile(jnp.eye(L), (1, T, 1, 1))
-    z = jnp.zeros((1, T, L))
-    Z = jnp.tile(jnp.eye(L), (1, T, 1, 1))
+    j = jnp.ones((1, T, K))
+    J = jnp.tile(jnp.eye(K), (1, T, 1, 1))
+    m = jnp.zeros((1, T, K))
+    V = jnp.tile(jnp.eye(K), (1, T, 1, 1))
     y = jnp.zeros((1, T, 5))
     valid_y = jnp.ones((1, T))
-    params = Params(C=jnp.ones((5, L)), d=jnp.zeros(5), R=jnp.eye(5), M=jnp.eye(L))
+    params = Params(C=jnp.ones((5, K)), d=jnp.zeros(5), R=jnp.eye(5))
 
-    j_out, J_out = Gaussian.update_pseudo(params, y, valid_y, z, Z, j, J, 0.1)
-    npt.assert_array_equal(np.asarray(j_out), np.asarray(j))
-    npt.assert_array_equal(np.asarray(J_out), np.asarray(J))
-
-
-def test_gaussian_infer_single_cvi_iter():
-    """Gaussian.infer forces cvi_iter=1 regardless of the argument."""
-    L = 2
-    T = 5
-
-    def mock_smooth(j, J, z0, Z0, Af, Pf, Ab, Pb):
-        return j, J  # return z, Z as dummies
-
-    j = jnp.zeros((1, T, L))
-    J = jnp.tile(jnp.eye(L), (1, T, 1, 1))
-    y = jnp.zeros((1, T, 4))
-    valid_y = jnp.ones((1, T))
-    z0 = jnp.zeros((1, L))
-    Z0 = jnp.tile(jnp.eye(L), (1, 1, 1))
-    params = Params(C=jnp.ones((4, L)), d=jnp.zeros(4), R=jnp.eye(4), M=jnp.eye(L))
-
-    smooth_args = (jnp.eye(L),) * 4  # Af, Pf, Ab, Pb
-
-    # Pass cvi_iter=10, but Gaussian should force it to 1
-    (z_out, Z_out), (j_out, J_out) = Gaussian.infer(
-        params, j, J, y, valid_y, z0, Z0, mock_smooth, smooth_args, cvi_iter=10, lr=0.1
-    )
-    # Gaussian.update_pseudo is a no-op so j_out == j, J_out == J
+    j_out, J_out = Gaussian.update_pseudo(params, y, valid_y, m, V, j, J, 0.1)
     npt.assert_array_equal(np.asarray(j_out), np.asarray(j))
     npt.assert_array_equal(np.asarray(J_out), np.asarray(J))
 
@@ -115,34 +94,77 @@ def test_poisson_cvi_masked_zero():
 
 def test_poisson_cvi_gradient_direction(rng):
     """One Poisson CVI step should not increase the negative ELL."""
-    T, N, L = 30, 5, 2
-    state_dim = L * 2  # real repr doubles
+    T, N, K = 30, 5, 2
 
-    C_raw = jnp.array(rng.standard_normal((N, L)) * 0.3)
+    C_raw = jnp.array(rng.standard_normal((N, K)) * 0.3)
     d = jnp.ones(N)
-    M = jnp.zeros((L, state_dim))
-    for i in range(L):
-        M = M.at[i, i * 2].set(1.0)
-    params = Params(C=C_raw, d=d, R=None, M=M)
+    params = Params(C=C_raw, d=d, R=None)
 
-    x = jnp.array(rng.standard_normal((1, T, L)) * 0.5)
+    x = jnp.array(rng.standard_normal((1, T, K)) * 0.5)
     eta = x @ C_raw.T + d
     y = jnp.array(rng.poisson(np.exp(np.asarray(eta))).astype(float))
     valid_y = jnp.ones((1, T))
 
-    # Initialize pseudo-obs
-    H = norm_loading(C_raw) @ M
-    j = jnp.zeros((1, T, state_dim))
-    J = jnp.tile(jnp.eye(state_dim) * 0.1, (1, T, 1, 1))
+    # Initialize pseudo-obs in latent space
+    j = jnp.zeros((1, T, K))
+    J = jnp.tile(jnp.eye(K) * 0.1, (1, T, 1, 1))
 
-    z = j.copy()
-    Z = J + jnp.tile(jnp.eye(state_dim), (1, T, 1, 1))
+    # Latent-space posterior moments
+    m = jnp.zeros((1, T, K))
+    V = jnp.tile(jnp.eye(K), (1, T, 1, 1))
 
     # One update
-    j_new, J_new = Poisson.update_pseudo(params, y, valid_y, z, Z, j, J, lr=0.5)
+    j_new, J_new = Poisson.update_pseudo(params, y, valid_y, m, V, j, J, lr=0.5)
 
     # j_new and J_new should differ from the initial values
     assert not jnp.allclose(j_new, j), "CVI update produced no change"
+
+
+def test_poisson_cvi_bin_stats_latent_equivalence(rng):
+    """Latent-space Poisson CVI stats match state-space version when M = I.
+
+    Temporary equivalence test for the refactor.  Remove after migration.
+    """
+    N, K = 5, 3
+    C_raw = jnp.array(rng.standard_normal((N, K)) * 0.3)
+    C = norm_loading(C_raw)
+    d = jnp.array(rng.standard_normal(N))
+    y = jnp.array(rng.poisson(5.0, size=N).astype(float))
+
+    # Build state-space info for M = I (K = L)
+    V_latent = jnp.eye(K) * 2.0
+    Z_state = jnp.linalg.inv(V_latent)
+    m_latent = jnp.array(rng.standard_normal(K))
+    z_state = Z_state @ m_latent
+
+    # State-space version with H = C @ I = C
+    H = C  # since M = I
+    k_state, K_state = poisson_cvi_bin_stats(z_state, Z_state, y, jnp.array(1.0), H, d)
+
+    # Latent-space version
+    k_latent, K_latent = poisson_cvi_bin_stats_latent(
+        m_latent, V_latent, y, jnp.array(1.0), C, d
+    )
+
+    # Tolerance is relaxed because the state-space version applies SVD
+    # regularisation (TAU) before converting to moments, introducing small
+    # numerical differences.
+    npt.assert_allclose(np.asarray(k_latent), np.asarray(k_state), atol=1e-4)
+    npt.assert_allclose(np.asarray(K_latent), np.asarray(K_state), atol=1e-4)
+
+
+def test_poisson_cvi_bin_stats_latent_masked(rng):
+    """Masked bins contribute zero CVI gradients from latent-space stats."""
+    N, K = 5, 3
+    C = jnp.array(rng.standard_normal((N, K)) * 0.3)
+    d = jnp.zeros(N)
+    m = jnp.ones(K)
+    V = jnp.eye(K)
+    y = jnp.ones(N) * 10.0
+
+    k_off, K_off = poisson_cvi_bin_stats_latent(m, V, y, jnp.array(0.0), C, d)
+    npt.assert_array_equal(np.asarray(k_off), 0.0)
+    npt.assert_array_equal(np.asarray(K_off), 0.0)
 
 
 def test_gaussian_e2e(linear_gaussian_data):

--- a/tests/test_parity.py
+++ b/tests/test_parity.py
@@ -442,21 +442,19 @@ def test_poisson_cvi_step_parity():
     # Build params — cvhmax normalises C internally via norm_loading,
     # so H will differ from the reference H_np.  We test shapes + finiteness.
     C_jax = jnp.array(C_np)
-    params = Params(C=C_jax, d=jnp.array(d_np), R=None, M=jnp.array(M))
+    params = Params(C=C_jax, d=jnp.array(d_np), R=None)
     y_jax = jnp.array(y_np)
     valid_y_jax = jnp.ones((1, T))
 
-    j_jax, J_jax = vmap(Poisson.initialize_info, in_axes=(None, 0, 0, None, None))(
+    j_jax, J_jax = vmap(Poisson.initialize_info, in_axes=(None, 0, 0))(
         params,
         y_jax,
         valid_y_jax,
-        jnp.array(A_real),
-        jnp.array(Q_real),
     )
 
-    # Both should produce finite outputs of matching shape
-    assert j_jax.shape == (1, T, state_dim)
-    assert J_jax.shape == (1, T, state_dim, state_dim)
+    # initialize_info now returns latent-space arrays
+    assert j_jax.shape == (1, T, L)
+    assert J_jax.shape == (1, T, L, L)
     assert np.all(np.isfinite(np.asarray(j_jax))), "cvhmax j has non-finite values"
     assert np.all(np.isfinite(np.asarray(J_jax))), "cvhmax J has non-finite values"
     assert np.all(np.isfinite(h_obs_ref_np)), "ref h_obs has non-finite values"


### PR DESCRIPTION
## Summary

Three-way separation of concerns: CVI (latent space), Filtering (state space), CVHM (bridge).

### Key changes

- **CVI is now stateless and latent-space only** — no dynamics knowledge, no `M`, no `infer` loop
- **CVHM owns the bridge** — `lift()` (latent→state) and `project()` (state→latent) via `M`
- **CVI loop moved to CVHM** — lift → bifilter → project → `update_pseudo` cycle
- **Forward-filter warm-up in CVHM** — replaces the old sequential init that was inside `Poisson.initialize_info`, preserving inference quality without CVI knowing about dynamics
- **Duck-typed params** — `Params` is a convenience dataclass, not a requirement; CVHM treats params as opaque
- **Benchmark regression guard** — 3 slow tests (`--run-slow`) assert R² ≥ 0.96 on Poisson-VdP scenarios

### Files changed (12 files, +852 −367)

| File | Change |
|------|--------|
| `src/cvhmax/cvi.py` | Remove `M` from Params, remove `infer`, latent-space `initialize_info`/`update_pseudo` |
| `src/cvhmax/cvhm.py` | Add `lift`/`project`, CVI loop, forward-filter warm-up |
| `src/cvhmax/__init__.py` | Export `lift`, `project` |
| `examples/demo_vdp.py` | Drop `M=` from Params constructor |
| `tests/test_benchmark.py` | New — 3 slow benchmark tests |
| `tests/test_cvhm.py` | Add lift/project unit tests |
| `tests/test_cvi.py` | Update for new signatures, add latent-space equivalence tests |
| `tests/test_parity.py` | Update for removed `M`/`lmask` |
| `tests/conftest.py` | Add `--run-slow` flag |
| `docs/architecture.md` | New — three-way separation design doc |
| `docs/algorithms.md` | CVI-EM loop pseudocode with warm-up |
| `docs/api.md`, `docs/data-model.md` | Updated for new API surface |
| `AGENTS.md` | Benchmark command + regression guard policy |

### Test results

- **377 passed, 12 skipped** (default pytest — 3 benchmark tests skipped)
- **380 passed, 9 skipped** (with `--run-slow`)
- Demo R² matches baseline (~0.972 on all three VdP scenarios)
- Lint clean on all changed files