### PR TITLE
feat(build): adopt hatch-vcs for dynamic versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ outputs
 *.npz
 hida_matern_gp_lvms/
 uv.lock
+# hatch-vcs generated
+src/cvhmax/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ authors = [
     { name = "yuanz", email = "yuanz271@gmail.com" }
 ]
 dependencies = [
-    "jax==0.4.38;platform_machine == 'x86_64'",
     "jax>=0.4.38",
     "jaxlib>=0.4.13",
     "numpy>=1.24.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cvhmax"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Add your description here"
 authors = [
     { name = "yuanz", email = "yuanz271@gmail.com" }
@@ -26,7 +26,7 @@ kergen = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.ruff.lint]
@@ -40,6 +40,12 @@ dev = [
     "torch>=2.1.0",
     "einops>=0.8.2",
 ]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/cvhmax/_version.py"
 
 [tool.hatch.metadata]
 allow-direct-references = true

--- a/src/cvhmax/__about__.py
+++ b/src/cvhmax/__about__.py
@@ -1,4 +1,0 @@
-# SPDX-FileCopyrightText: 2023-present yuanz <yuanz271@gmail.com>
-#
-# SPDX-License-Identifier: MIT
-__version__ = "0.1.0"

--- a/src/cvhmax/__init__.py
+++ b/src/cvhmax/__init__.py
@@ -1,3 +1,4 @@
+from ._version import __version__, __version_tuple__  # noqa: F401
 from .cvhm import CVHM, lift, project
 from .cvi import CVI, Gaussian, Poisson, Params
 from .hm import HidaMatern


### PR DESCRIPTION
## Summary

Adopt **hatch-vcs** so the package version is derived from git tags instead of a hardcoded string.

## Changes

- **pyproject.toml**: replace static `version` with `dynamic = ["version"]`; add `hatch-vcs` to build requires; add `[tool.hatch.version]` and `[tool.hatch.build.hooks.vcs]` sections
- **src/cvhmax/\_\_about\_\_.py**: deleted (superseded by auto-generated `_version.py`)
- **src/cvhmax/\_\_init\_\_.py**: import `__version__` / `__version_tuple__` from `._version`
- **.gitignore**: ignore generated `src/cvhmax/_version.py`
- **pyproject.toml**: drop x86_64-only `jax==0.4.38` pin

## Usage

Tag a release to set the version:
```bash
git tag v0.2.0
```
Between tags, dev versions are produced automatically (e.g. `0.2.0.dev3+gabcdef`).